### PR TITLE
Corrige comando incorreto de execução do Sonar Scanner no servidor do TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ before_install:
 script:
   #- ./gradlew check -PdisablePreDex --continue --stacktrace
   - adb devices
-  - sonar-scanner -Dsonar.login=$SONAR_TOKEN
+  - sonar-scanner -X -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN


### PR DESCRIPTION
O build no Travis CI estava falhando pelo seguinte motivo:
![travis-sonarscanner_failing](https://cloud.githubusercontent.com/assets/9777954/20832434/6da1474c-b871-11e6-9945-8312cfa3e6ea.jpg)

O PR deve resolver esse problema e avaliar a qualidade do código do DroidMetronome.